### PR TITLE
Add http-service-hyper as a workspace member

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ license = "MIT OR Apache-2.0"
 name = "http-service"
 version = "0.1.4"
 
+[workspace]
+members = ["http-service-hyper"]
+
 [dependencies]
 bytes = "0.4.11"
 http = "0.1.13"

--- a/http-service-hyper/Cargo.toml
+++ b/http-service-hyper/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+authors = [
+    "Aaron Turon <aturon@mozilla.com>",
+    "Yoshua Wuyts <yoshuawuyts@gmail.com>",
+    "Wonwoo Choi <chwo9843@gmail.com>",
+]
+description = "HttpService server that uses Hyper as backend"
+edition = "2018"
+license = "MIT OR Apache-2.0"
+name = "http-service-hyper"
+repository = "https://github.com/rust-net-web/http-service"
+version = "0.1.0"
+
+[dependencies]
+http = "0.1"
+http-service = "0.1.4"
+hyper = "0.12.24"
+
+[dependencies.futures-preview]
+features = ["compat"]
+version = "0.3.0-alpha.13"

--- a/http-service-hyper/src/lib.rs
+++ b/http-service-hyper/src/lib.rs
@@ -1,0 +1,95 @@
+//! `HttpService` server that uses Hyper as backend.
+#![cfg_attr(feature = "nightly", deny(missing_docs))]
+#![feature(futures_api, async_await, await_macro)]
+
+use futures::{
+    compat::{Compat, Compat01As03, Future01CompatExt},
+    future::FutureObj,
+    prelude::*,
+};
+use http_service::{Body, HttpService};
+use std::{net::SocketAddr, sync::Arc};
+
+// Wrapper type to allow us to provide a blanket `MakeService` impl
+struct WrapHttpService<H> {
+    service: Arc<H>,
+}
+
+// Wrapper type to allow us to provide a blanket `Service` impl
+struct WrapConnection<H: HttpService> {
+    service: Arc<H>,
+    connection: H::Connection,
+}
+
+impl<H, Ctx> hyper::service::MakeService<Ctx> for WrapHttpService<H>
+where
+    H: HttpService,
+{
+    type ReqBody = hyper::Body;
+    type ResBody = hyper::Body;
+    type Error = std::io::Error;
+    type Service = WrapConnection<H>;
+    type Future = Compat<FutureObj<'static, Result<Self::Service, Self::Error>>>;
+    type MakeError = std::io::Error;
+
+    fn make_service(&mut self, _ctx: Ctx) -> Self::Future {
+        let service = self.service.clone();
+        let error = std::io::Error::from(std::io::ErrorKind::Other);
+        FutureObj::new(Box::new(
+            async move {
+                let connection = await!(service.connect().into_future()).map_err(|_| error)?;
+                Ok(WrapConnection {
+                    service,
+                    connection,
+                })
+            },
+        ))
+        .compat()
+    }
+}
+
+impl<H> hyper::service::Service for WrapConnection<H>
+where
+    H: HttpService,
+{
+    type ReqBody = hyper::Body;
+    type ResBody = hyper::Body;
+    type Error = std::io::Error;
+    type Future = Compat<FutureObj<'static, Result<http::Response<hyper::Body>, Self::Error>>>;
+
+    fn call(&mut self, req: http::Request<hyper::Body>) -> Self::Future {
+        let error = std::io::Error::from(std::io::ErrorKind::Other);
+        let req = req.map(|hyper_body| {
+            let stream = Compat01As03::new(hyper_body).map(|c| match c {
+                Ok(chunk) => Ok(chunk.into_bytes()),
+                Err(e) => Err(std::io::Error::new(std::io::ErrorKind::Other, e)),
+            });
+            Body::from_stream(stream)
+        });
+        let fut = self.service.respond(&mut self.connection, req);
+
+        FutureObj::new(Box::new(
+            async move {
+                let res: http::Response<_> = await!(fut.into_future()).map_err(|_| error)?;
+                Ok(res.map(|body| hyper::Body::wrap_stream(body.compat())))
+            },
+        ))
+        .compat()
+    }
+}
+
+/// Serve the given `HttpService` at the given address, using `hyper` as backend.
+pub fn serve<S: HttpService>(s: S, addr: SocketAddr) {
+    let service = WrapHttpService {
+        service: Arc::new(s),
+    };
+    let server = hyper::Server::bind(&addr)
+        .serve(service)
+        .compat()
+        .map(|_| {
+            let res: Result<(), ()> = Ok(());
+            res
+        })
+        .compat();
+    hyper::rt::run(server);
+}


### PR DESCRIPTION
From rust-net-web/tide#140, I'm moving `http-service-hyper` here.