### PR TITLE
Add http-service-mock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "http-service"
 version = "0.1.4"
 
 [workspace]
-members = ["http-service-hyper"]
+members = ["http-service-hyper", "http-service-mock"]
 
 [dependencies]
 bytes = "0.4.11"

--- a/http-service-mock/Cargo.toml
+++ b/http-service-mock/Cargo.toml
@@ -4,11 +4,11 @@ description = "Creates a HttpService server mock to test requests/responses agai
 edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "http-service-mock"
+repository = "https://github.com/rust-net-web/http-service"
 version = "0.1.0"
 
 [dependencies]
 http-service = "0.1.4"
 
 [dependencies.futures-preview]
-features = ["compat"]
 version = "0.3.0-alpha.13"

--- a/http-service-mock/Cargo.toml
+++ b/http-service-mock/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
-authors = ["Bastian Gruber <gruberbastian@me.com>"]
+authors = [
+    "Bastian Gruber <gruberbastian@me.com>",
+    "Wonwoo Choi <chwo9843@gmail.com>",
+]
 description = "Creates a HttpService server mock to test requests/responses against your app"
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/http-service-mock/Cargo.toml
+++ b/http-service-mock/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+authors = ["Bastian Gruber <gruberbastian@me.com>"]
+description = "Creates a HttpService server mock to test requests/responses against your app"
+edition = "2018"
+license = "MIT OR Apache-2.0"
+name = "http-service-mock"
+version = "0.1.0"
+
+[dependencies]
+http-service = "0.1.4"
+
+[dependencies.futures-preview]
+features = ["compat"]
+version = "0.3.0-alpha.13"

--- a/http-service-mock/src/lib.rs
+++ b/http-service-mock/src/lib.rs
@@ -1,0 +1,32 @@
+#![cfg_attr(feature = "nightly", deny(missing_docs))]
+#![feature(futures_api, async_await, await_macro, arbitrary_self_types)]
+
+use futures::{executor::block_on, prelude::*};
+use http_service::{HttpService, Request, Response};
+
+pub struct TestBackend<T: HttpService> {
+    service: T,
+    connection: T::Connection,
+}
+
+impl<T: HttpService> TestBackend<T> {
+    fn wrap(service: T) -> Result<Self, <T::ConnectionFuture as TryFuture>::Error> {
+        let connection = block_on(service.connect().into_future())?;
+        Ok(Self {
+            service,
+            connection,
+        })
+    }
+
+    pub fn simulate(&mut self, req: Request) -> Result<Response, <T::Fut as TryFuture>::Error> {
+        block_on(
+            self.service
+                .respond(&mut self.connection, req)
+                .into_future(),
+        )
+    }
+}
+
+pub fn make_server(service: HttpService) -> TestBackend<HttpService> {
+    TestBackend::wrap(service).unwrap()
+}

--- a/http-service-mock/src/lib.rs
+++ b/http-service-mock/src/lib.rs
@@ -26,6 +26,6 @@ impl<T: HttpService> TestBackend<T> {
     }
 }
 
-pub fn make_server<T: HttpService> (service: T) -> Result<TestBackend<T>, <T::ConnectionFuture as TryFuture>::Error> {
+pub fn make_server<T: HttpService>(service: T) -> Result<TestBackend<T>, <T::ConnectionFuture as TryFuture>::Error> {
     TestBackend::wrap(service)
 }

--- a/http-service-mock/src/lib.rs
+++ b/http-service-mock/src/lib.rs
@@ -27,6 +27,6 @@ impl<T: HttpService> TestBackend<T> {
     }
 }
 
-pub fn make_server(T: HttpService) -> TestBackend<T::Fut as TryFuture> {
+pub fn make_server(T: HttpService) -> TestBackend<T::ConnectionFuture> {
     TestBackend::wrap(T).unwrap()
 }

--- a/http-service-mock/src/lib.rs
+++ b/http-service-mock/src/lib.rs
@@ -27,6 +27,6 @@ impl<T: HttpService> TestBackend<T> {
     }
 }
 
-pub fn make_server(service: HttpService) -> TestBackend<HttpService> {
+pub fn make_server(service: HttpService) -> TestBackend<F> {
     TestBackend::wrap(service).unwrap()
 }

--- a/http-service-mock/src/lib.rs
+++ b/http-service-mock/src/lib.rs
@@ -1,5 +1,4 @@
-#![cfg_attr(feature = "nightly", deny(missing_docs))]
-#![feature(futures_api, async_await, await_macro, arbitrary_self_types)]
+#![feature(futures_api, async_await)]
 
 use futures::{executor::block_on, prelude::*};
 use http_service::{HttpService, Request, Response};
@@ -27,6 +26,6 @@ impl<T: HttpService> TestBackend<T> {
     }
 }
 
-pub fn make_server(T: HttpService) -> TestBackend<T::ConnectionFuture> {
-    TestBackend::wrap(T).unwrap()
+pub fn make_server<T: HttpService> (service: T) -> Result<TestBackend<T>, <T::ConnectionFuture as TryFuture>::Error> {
+    TestBackend::wrap(service)
 }

--- a/http-service-mock/src/lib.rs
+++ b/http-service-mock/src/lib.rs
@@ -27,6 +27,6 @@ impl<T: HttpService> TestBackend<T> {
     }
 }
 
-pub fn make_server(service: HttpService) -> TestBackend<F> {
-    TestBackend::wrap(service).unwrap()
+pub fn make_server(T: HttpService) -> TestBackend<T::Fut as TryFuture> {
+    TestBackend::wrap(T).unwrap()
 }


### PR DESCRIPTION
## Description
I added the TestBackend, created here https://github.com/rust-net-web/tide/issues/15, as a workspace member.

## Motivation and Context
Moving the created TestBackend from `Tide` into `http-service`, so we have a more general way of creating mocks and running tests against it.

~~I would need help with this. What I have problems with is the return type of the `make_server`. I assume its getting passed an `HttpService`, wraps it and returns, also an `HttpService`? I am digging through `HttpService` and `Tide` for a few days now and can't seem to figure it out.~~

This is part of the Testing issue https://github.com/rust-net-web/tide/issues/15 in `Tide`

## Types of changes
- [x] Create a workspace member `http-service-mock`
- [x] Moving from the tight integration from `Tide` to a more general approach

## Checklist:
- [x] Create workspace member
- [x] Remove `Tide` integration
- [x] Pass a `HttpService` to `make_server` and return appropriate type 
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
