### PR TITLE
http-service-hyper: Make serve return a Future

### DIFF
--- a/http-service-hyper/src/lib.rs
+++ b/http-service-hyper/src/lib.rs
@@ -78,17 +78,9 @@ where
     }
 }
 
-/// Serve the given `HttpService` at the given address, using `hyper` as backend.
-pub fn serve<S: HttpService>(s: S, addr: SocketAddr) {
-    let server = serve_async(s, addr)
-        .map(|_| Result::<_, ()>::Ok(()))
-        .compat();
-    hyper::rt::run(server);
-}
-
 /// Serve the given `HttpService` at the given address, using `hyper` as backend, and return a
 /// `Future` that can be `await`ed on.
-pub fn serve_async<S: HttpService>(
+pub fn serve<S: HttpService>(
     s: S,
     addr: SocketAddr,
 ) -> impl Future<Output = Result<(), hyper::Error>> {
@@ -96,4 +88,11 @@ pub fn serve_async<S: HttpService>(
         service: Arc::new(s),
     };
     hyper::Server::bind(&addr).serve(service).compat()
+}
+
+/// Run the given `HttpService` at the given address on the default runtime, using `hyper` as
+/// backend.
+pub fn run<S: HttpService>(s: S, addr: SocketAddr) {
+    let server = serve(s, addr).map(|_| Result::<_, ()>::Ok(())).compat();
+    hyper::rt::run(server);
 }


### PR DESCRIPTION
## Description
- Renamed the original `serve` to `run`.
- Added the new `serve` which returns a `Future` that can be awaited on.

## Motivation and Context
Using the new `serve`, server Future can be run concurrently with other Futures easily.

## How Has This Been Tested?
I've briefly tested `serve` with Tide and Runtime Tokio and it worked.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
