### PR TITLE
Add Futures return to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@
 ## About
 The crate `http-service` provides the necessary types and traits to implement your own HTTP Server. It uses `hyper` for the lower level TCP abstraction. 
 
-You can use the workspace member [`http-service-hyper`](https://crates.io/crates/http-service-hyper) to run your HTTP Server via `http_service_hyper::serve(HTTP_SERVICE, ADDRESS);`
+You can use the workspace member [`http-service-hyper`](https://crates.io/crates/http-service-hyper) to run your HTTP Server.
+
+1. Runs via `http_service_hyper::run(HTTP_SERVICE, ADDRESS);`
+2. Returns a future which can be `await`ed via `http_service_hyper::serve(HTTP_SERVICE, ADDRESS);`
 
 This crate uses the latest [Futures](https://github.com/rust-lang-nursery/futures-rs) preview, and therefore needs to be run on Rust Nightly.
 


### PR DESCRIPTION
Added `http_service_hyper::serve` to README and tell the reader it will return a Future which can be awaited.

## Description
Added a list of possible options to use `http_service_hyper` to run your HTTP-Service

## Motivation and Context
It explains the added feature of returning a Future or running it "directly" via http-service-hyper.

## How Has This Been Tested?
No test needed, just documentation.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
