### PR TITLE
Update futures-preview to 0.3.0-alpha.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - nightly-2019-04-25
+  - nightly-2019-05-09
 
 before_script: |
   rustup component add rustfmt clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ http = "0.1.17"
 http-service-hyper = { path = "http-service-hyper", version = "0.2.0" }
 
 [dependencies.futures-preview]
-version = "0.3.0-alpha.15"
+version = "0.3.0-alpha.16"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ version = "0.1.1"
 
 **main.rs**
 ```rust
-#![feature(futures_api, async_await, await_macro, existential_type)]
+#![feature(futures_api, async_await, existential_type)]
 
 use futures::future::{self, FutureObj};
 use http_service::{HttpService, Response};

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 </div>
 
 ## About
-The crate `http-service` provides the necessary types and traits to implement your own HTTP Server. It uses `hyper` for the lower level TCP abstraction. 
+The crate `http-service` provides the necessary types and traits to implement your own HTTP Server. It uses `hyper` for the lower level TCP abstraction.
 
 You can use the workspace member [`http-service-hyper`](https://crates.io/crates/http-service-hyper) to run your HTTP Server.
 
@@ -70,7 +70,7 @@ version = "0.1.1"
 
 **main.rs**
 ```rust
-#![feature(futures_api, async_await, existential_type)]
+#![feature(async_await, existential_type)]
 
 use futures::future::{self, FutureObj};
 use http_service::{HttpService, Response};

--- a/examples/simple_response.rs
+++ b/examples/simple_response.rs
@@ -1,4 +1,4 @@
-#![feature(async_await, await_macro, existential_type)]
+#![feature(async_await, existential_type)]
 
 use futures::future::{self, FutureObj};
 use http_service::{HttpService, Response};

--- a/http-service-hyper/Cargo.toml
+++ b/http-service-hyper/Cargo.toml
@@ -18,4 +18,4 @@ hyper = "0.12.27"
 
 [dependencies.futures-preview]
 features = ["compat"]
-version = "0.3.0-alpha.15"
+version = "0.3.0-alpha.16"

--- a/http-service-hyper/src/lib.rs
+++ b/http-service-hyper/src/lib.rs
@@ -4,7 +4,7 @@
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs, missing_doc_code_examples)]
 #![cfg_attr(test, deny(warnings))]
-#![feature(async_await, await_macro)]
+#![feature(async_await)]
 
 use futures::{
     compat::{Compat, Compat01As03, Future01CompatExt},
@@ -40,7 +40,7 @@ where
         let service = self.service.clone();
         let error = std::io::Error::from(std::io::ErrorKind::Other);
         async move {
-            let connection = await!(service.connect().into_future()).map_err(|_| error)?;
+            let connection = service.connect().into_future().await.map_err(|_| error)?;
             Ok(WrapConnection {
                 service,
                 connection,
@@ -72,7 +72,7 @@ where
         let fut = self.service.respond(&mut self.connection, req);
 
         async move {
-            let res: http::Response<_> = await!(fut.into_future()).map_err(|_| error)?;
+            let res: http::Response<_> = fut.into_future().await.map_err(|_| error)?;
             Ok(res.map(|body| hyper::Body::wrap_stream(body.compat())))
         }
             .boxed()

--- a/http-service-mock/Cargo.toml
+++ b/http-service-mock/Cargo.toml
@@ -14,4 +14,4 @@ version = "0.2.0"
 http-service = { version = "0.2.0", path = ".." }
 
 [dependencies.futures-preview]
-version = "0.3.0-alpha.15"
+version = "0.3.0-alpha.16"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! ## Example
 //! ```no_run, rust, ignore
-//! #![feature(futures_api, async_await, await_macro, existential_type)]
+//! #![feature(futures_api, async_await, existential_type)]
 //!
 //! use futures::{
 //!     future::{self, FutureObj},
@@ -57,7 +57,7 @@
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs, missing_doc_code_examples)]
 #![cfg_attr(test, deny(warnings))]
-#![feature(async_await, await_macro, arbitrary_self_types)]
+#![feature(async_await, arbitrary_self_types)]
 
 use bytes::Bytes;
 use futures::{
@@ -100,7 +100,7 @@ impl Body {
     #[allow(clippy::wrong_self_convention)] // https://github.com/rust-lang/rust-clippy/issues/4037
     pub async fn into_vec(mut self) -> std::io::Result<Vec<u8>> {
         let mut bytes = Vec::new();
-        while let Some(chunk) = await!(self.next()) {
+        while let Some(chunk) = self.next().await {
             bytes.extend(chunk?);
         }
         Ok(bytes)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! ## Example
 //! ```no_run, rust, ignore
-//! #![feature(futures_api, async_await, existential_type)]
+//! #![feature(async_await, existential_type)]
 //!
 //! use futures::{
 //!     future::{self, FutureObj},
@@ -64,12 +64,10 @@ use futures::{
     future,
     prelude::*,
     stream::{self, BoxStream},
-    task::Context,
-    Poll,
+    task::{Context, Poll},
 };
 
 use std::fmt;
-use std::marker::Unpin;
 use std::pin::Pin;
 
 /// The raw body of an http request or response.
@@ -96,7 +94,6 @@ impl Body {
     }
 
     /// Reads the stream into a new `Vec`.
-    #[allow(unused_mut)]
     #[allow(clippy::wrong_self_convention)] // https://github.com/rust-lang/rust-clippy/issues/4037
     pub async fn into_vec(mut self) -> std::io::Result<Vec<u8>> {
         let mut bytes = Vec::new();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`await` syntax was implemented in https://github.com/rust-lang/rust/pull/60586, and nightly-2019-05-09 has been released with the changes. Also, `await!` macro will be removed in the future.

Then, futures 0.3.0-alpha.16 was released.

Refs: [migration tool](https://github.com/taiki-e/replace-await)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

With this change, the minimum required version will go up to nightly-2019-05-09.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
