### PR TITLE
Rename `Fut` to `ResponseFuture`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ impl Server {
 impl HttpService for Server {
     type Connection = ();
     type ConnectionFuture = future::Ready<Result<(), std::io::Error>>;
-    type Fut = FutureObj<'static, Result<http_service::Response, std::io::Error>>;
+    type ResponseFuture = FutureObj<'static, Result<http_service::Response, std::io::Error>>;
 
     fn connect(&self) -> Self::ConnectionFuture {
         future::ok(())
     }
 
-    fn respond(&self, _conn: &mut (), _req: http_service::Request) -> Self::Fut {
+    fn respond(&self, _conn: &mut (), _req: http_service::Request) -> Self::ResponseFuture {
         let message = self.message.clone();
         FutureObj::new(Box::new(async move {
             Ok(Response::new(http_service::Body::from(message)))

--- a/examples/simple_response.rs
+++ b/examples/simple_response.rs
@@ -22,13 +22,13 @@ impl Server {
 impl HttpService for Server {
     type Connection = ();
     type ConnectionFuture = future::Ready<Result<(), std::io::Error>>;
-    type Fut = FutureObj<'static, Result<http_service::Response, std::io::Error>>;
+    type ResponseFuture = FutureObj<'static, Result<http_service::Response, std::io::Error>>;
 
     fn connect(&self) -> Self::ConnectionFuture {
         future::ok(())
     }
 
-    fn respond(&self, _conn: &mut (), _req: http_service::Request) -> Self::Fut {
+    fn respond(&self, _conn: &mut (), _req: http_service::Request) -> Self::ResponseFuture {
         let message = self.message.clone();
         FutureObj::new(Box::new(async move {
             Ok(Response::new(http_service::Body::from(message)))

--- a/http-service-mock/src/lib.rs
+++ b/http-service-mock/src/lib.rs
@@ -26,7 +26,10 @@ impl<T: HttpService> TestBackend<T> {
     }
 
     /// Send a request to the simulated server
-    pub fn simulate(&mut self, req: Request) -> Result<Response, <T::Fut as TryFuture>::Error> {
+    pub fn simulate(
+        &mut self,
+        req: Request,
+    ) -> Result<Response, <T::ResponseFuture as TryFuture>::Error> {
         block_on(
             self.service
                 .respond(&mut self.connection, req)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ impl Body {
     }
 
     /// Reads the stream into a new `Vec`.
+    #[allow(unused_mut)]
     #[allow(clippy::wrong_self_convention)] // https://github.com/rust-lang/rust-clippy/issues/4037
     pub async fn into_vec(mut self) -> std::io::Result<Vec<u8>> {
         let mut bytes = Vec::new();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Resolves https://github.com/rustasync/http-service/issues/24

## Motivation and Context
Currently, the associated params of HttpService are ConnectionFuture which corresponds to connect, and the Fut which corresponds to respond.

I think it'd be better to call this ResponseFuture such that it maintains parity.

`connect` -> `ConnectionFuture`
`respond` -> `ResponseFuture`

rather than the Fut that isn't really informative or intuitive.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
