### PR TITLE
Allow configuring the spawner used and disabling the hyper runtime

### DIFF
--- a/http-service-hyper/Cargo.toml
+++ b/http-service-hyper/Cargo.toml
@@ -15,8 +15,15 @@ version = "0.2.0"
 [dependencies]
 http = "0.1"
 http-service = { version = "0.2.0", path = ".." }
-hyper = "0.12.27"
+hyper = { version = "0.12.27", default-features = false }
 
 [dependencies.futures-preview]
-features = ["compat"]
+features = ["compat", "io-compat"]
 version = "0.3.0-alpha.16"
+
+[features]
+default = ["runtime"]
+runtime = ["hyper/runtime"]
+
+[dev-dependencies]
+romio = "0.3.0-alpha.8"

--- a/http-service-hyper/src/lib.rs
+++ b/http-service-hyper/src/lib.rs
@@ -6,13 +6,24 @@
 #![cfg_attr(test, deny(warnings))]
 #![feature(async_await)]
 
+#[cfg(feature = "runtime")]
+use futures::compat::Future01CompatExt;
 use futures::{
-    compat::{Compat, Compat01As03, Future01CompatExt},
+    compat::{Compat, Compat01As03},
     future::BoxFuture,
     prelude::*,
+    stream,
+    task::Spawn,
 };
 use http_service::{Body, HttpService};
-use std::{net::SocketAddr, sync::Arc};
+use hyper::server::{Builder as HyperBuilder, Server as HyperServer};
+#[cfg(feature = "runtime")]
+use std::net::SocketAddr;
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{self, Poll},
+};
 
 // Wrapper type to allow us to provide a blanket `MakeService` impl
 struct WrapHttpService<H> {
@@ -80,8 +91,120 @@ where
     }
 }
 
+/// A listening HTTP server that accepts connections in both HTTP1 and HTTP2 by default.
+///
+/// [`Server`] is a [`Future`] mapping a bound listener with a set of service handlers. It is built
+/// using the [`Builder`], and the future completes when the server has been shutdown. It should be
+/// run by an executor.
+#[allow(clippy::type_complexity)] // single-use type with many compat layers
+pub struct Server<I: TryStream, S, Sp> {
+    inner: Compat01As03<
+        HyperServer<
+            Compat<stream::MapOk<I, fn(I::Ok) -> Compat<I::Ok>>>,
+            WrapHttpService<S>,
+            Compat<Sp>,
+        >,
+    >,
+}
+
+impl<I: TryStream, S, Sp> std::fmt::Debug for Server<I, S, Sp> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Server").finish()
+    }
+}
+
+/// A builder for a [`Server`].
+#[allow(clippy::type_complexity)] // single-use type with many compat layers
+pub struct Builder<I: TryStream, Sp> {
+    inner: HyperBuilder<Compat<stream::MapOk<I, fn(I::Ok) -> Compat<I::Ok>>>, Compat<Sp>>,
+}
+
+impl<I: TryStream, Sp> std::fmt::Debug for Builder<I, Sp> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Builder").finish()
+    }
+}
+
+impl<I: TryStream> Server<I, (), ()> {
+    /// Starts a [`Builder`] with the provided incoming stream.
+    pub fn builder(incoming: I) -> Builder<I, ()> {
+        Builder {
+            inner: HyperServer::builder(Compat::new(incoming.map_ok(Compat::new as _)))
+                .executor(Compat::new(())),
+        }
+    }
+}
+
+impl<I: TryStream, Sp> Builder<I, Sp> {
+    /// Sets the [`Spawn`] to deal with starting connection tasks.
+    pub fn with_spawner<Sp2>(self, new_spawner: Sp2) -> Builder<I, Sp2> {
+        Builder {
+            inner: self.inner.executor(Compat::new(new_spawner)),
+        }
+    }
+
+    /// Consume this [`Builder`], creating a [`Server`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use http_service::{Response, Body};
+    /// use http_service_hyper::Server;
+    /// use romio::TcpListener;
+    ///
+    /// // Construct an executor to run our tasks on
+    /// let mut pool = futures::executor::ThreadPool::new()?;
+    ///
+    /// // And an HttpService to handle each connection...
+    /// let service = |req| {
+    ///     futures::future::ok::<_, ()>(Response::new(Body::from("Hello World")))
+    /// };
+    ///
+    /// // Then bind, configure the spawner to our pool, and serve...
+    /// let addr = "127.0.0.1:3000".parse()?;
+    /// let mut listener = TcpListener::bind(&addr)?;
+    /// let server = Server::builder(listener.incoming())
+    ///     .with_spawner(pool.clone())
+    ///     .serve(service);
+    ///
+    /// // Finally, spawn `server` onto our executor...
+    /// pool.run(server)?;
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    pub fn serve<S: HttpService>(self, service: S) -> Server<I, S, Sp>
+    where
+        I: TryStream + Unpin,
+        I::Ok: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+        I::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+        Sp: Clone + Send + 'static,
+        for<'a> &'a Sp: Spawn,
+    {
+        Server {
+            inner: Compat01As03::new(self.inner.serve(WrapHttpService {
+                service: Arc::new(service),
+            })),
+        }
+    }
+}
+
+impl<I, S, Sp> Future for Server<I, S, Sp>
+where
+    I: TryStream + Unpin,
+    I::Ok: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+    I::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S: HttpService,
+    Sp: Clone + Send + 'static,
+    for<'a> &'a Sp: Spawn,
+{
+    type Output = hyper::Result<()>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<hyper::Result<()>> {
+        self.inner.poll_unpin(cx)
+    }
+}
+
 /// Serve the given `HttpService` at the given address, using `hyper` as backend, and return a
 /// `Future` that can be `await`ed on.
+#[cfg(feature = "runtime")]
 pub fn serve<S: HttpService>(
     s: S,
     addr: SocketAddr,
@@ -94,6 +217,7 @@ pub fn serve<S: HttpService>(
 
 /// Run the given `HttpService` at the given address on the default runtime, using `hyper` as
 /// backend.
+#[cfg(feature = "runtime")]
 pub fn run<S: HttpService>(s: S, addr: SocketAddr) {
     let server = serve(s, addr).map(|_| Result::<_, ()>::Ok(())).compat();
     hyper::rt::run(server);


### PR DESCRIPTION
## Description
Allows disabling the Tokio dependency and running hyper on top of a futures 0.3 executor and IO provider (e.g. `futures::executor::ThreadPool` + `romio` as used in the doc example, or `runtime` as I have tested in my own project).

I'm not sure whether there is a better pattern for this configuration, I basically was keeping the API as close as possible to what is provided by `hyper` to make developing it easier.

This is _technically_ a breaking change because of the newly introduced default-enabled feature.
<!--- Describe your changes in detail -->

## Motivation and Context
Mainly motivated by wanting to ensure https://github.com/rustasync/tide/issues/276 is actually solvable.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Example makes sure it compiles, and using it in my own Tide project it is working fine.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.