### PR TITLE
Implement a HttpService backend that runs on the AWS Lambda Rust Runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,9 @@ http-service-hyper = { path = "http-service-hyper", version = "0.2.0" }
 
 [dependencies.futures-preview]
 version = "0.3.0-alpha.16"
+
+[patch.crates-io]
+http-service = { path = "." }
+http-service-mock = { path = "./http-service-mock" }
+http-service-hyper = { path = "./http-service-hyper" }
+tide = { git = "https://github.com/rustasync/tide", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "http-service"
 version = "0.2.0"
 
 [workspace]
-members = ["http-service-hyper", "http-service-mock"]
+members = ["http-service-hyper", "http-service-lambda", "http-service-mock"]
 
 [dependencies]
 bytes = "0.4.12"

--- a/http-service-lambda/Cargo.toml
+++ b/http-service-lambda/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+authors = ["Kan-Ru Chen <kanru@kanru.info>"]
+description = "HttpService server that AWS Lambda Rust Runtime as backend"
+documentation = "https://docs.rs/http-service-lambda"
+edition = "2018"
+license = "MIT OR Apache-2.0"
+name = "http-service-lambda"
+repository = "https://github.com/rustasync/http-service"
+version = "0.1.0"
+
+[dependencies]
+http-service = "0.2.0"
+lambda_http = "0.1.1"
+lambda_runtime = "0.2.1"
+tokio = "0.1.21"
+
+[dependencies.futures-preview]
+features = ["compat"]
+version = "0.3.0-alpha.16"
+
+[dev-dependencies]
+log = "0.4.6"
+simple_logger = { version = "1.3.0", default-features = false }
+tide = "0.2.0"

--- a/http-service-lambda/Cargo.toml
+++ b/http-service-lambda/Cargo.toml
@@ -1,5 +1,9 @@
 [package]
-authors = ["Kan-Ru Chen <kanru@kanru.info>"]
+authors = [
+  "Aaron Turon <aturon@mozilla.com>",
+  "Yoshua Wuyts <yoshuawuyts@gmail.com>",
+  "Kan-Ru Chen <kanru@kanru.info>",
+]
 description = "HttpService server that AWS Lambda Rust Runtime as backend"
 documentation = "https://docs.rs/http-service-lambda"
 edition = "2018"

--- a/http-service-lambda/examples/README.md
+++ b/http-service-lambda/examples/README.md
@@ -1,0 +1,23 @@
+## Quick Start
+
+See the document for
+[aws-lambda-rust-runtime](https://github.com/awslabs/aws-lambda-rust-runtime)
+for how to build and deploy a lambda function.
+
+Alternatively, build the example and deploy to lambda manually:
+
+1. Build with musl target
+
+    ```sh
+    rustup target add x86_64-unknown-linux-musl
+    cargo +nightly build --release --example hello_world --target x86_64-unknown-linux-musl
+    ```
+
+2. Package
+
+    ```sh
+    cp ../../target/x86_64-unknown-linux-musl/release/examples/hello_world bootstrap
+    zip lambda.zip bootstrap
+    ```
+
+3. Use [AWS CLI](https://aws.amazon.com/cli/) or AWS console to create new lambda function.

--- a/http-service-lambda/examples/hello_world.rs
+++ b/http-service-lambda/examples/hello_world.rs
@@ -1,0 +1,19 @@
+#![feature(async_await)]
+use simple_logger;
+use tide::middleware::DefaultHeaders;
+
+fn main() {
+    simple_logger::init_with_level(log::Level::Info).unwrap();
+
+    let mut app = tide::App::new(());
+
+    app.middleware(
+        DefaultHeaders::new()
+            .header("X-Version", "1.0.0")
+            .header("X-Server", "Tide"),
+    );
+
+    app.at("/").get(async move |_| "Hello, world!");
+
+    http_service_lambda::run(app.into_http_service());
+}

--- a/http-service-lambda/examples/hello_world.rs
+++ b/http-service-lambda/examples/hello_world.rs
@@ -5,7 +5,7 @@ use tide::middleware::DefaultHeaders;
 fn main() {
     simple_logger::init_with_level(log::Level::Info).unwrap();
 
-    let mut app = tide::App::new(());
+    let mut app = tide::App::new();
 
     app.middleware(
         DefaultHeaders::new()

--- a/http-service-lambda/src/lib.rs
+++ b/http-service-lambda/src/lib.rs
@@ -1,0 +1,179 @@
+//! `HttpService` server that uses AWS Lambda Rust Runtime as backend.
+//!
+//! This crate builds on the standard http interface provided by the
+//! [lambda_http](https://docs.rs/lambda_http) crate and provides a http server
+//! that runs on the lambda runtime.
+//!
+//! Compatible services like [tide](https://github.com/rustasync/tide) apps can
+//! run on lambda and processing events from API Gateway or ALB without much
+//! change.
+//!
+//! # Examples
+//!
+//! **Hello World**
+//!
+//! ```rust,ignore
+//! #![feature(async_await)]
+//!
+//! fn main() {
+//!     let mut app = tide::App::new();
+//!     app.at("/").get(async move |_| "Hello, world!");
+//!     http_service_lambda::run(app.into_http_service());
+//! }
+//! ```
+
+#![forbid(future_incompatible, rust_2018_idioms)]
+#![deny(missing_debug_implementations, nonstandard_style)]
+#![warn(missing_docs, missing_doc_code_examples)]
+#![cfg_attr(test, deny(warnings))]
+#![feature(async_await)]
+
+use futures::{FutureExt, TryFutureExt};
+use http_service::{Body as HttpBody, HttpService, Request as HttpRequest};
+use lambda_http::{Body as LambdaBody, Handler, Request as LambdaHttpRequest};
+use lambda_runtime::{error::HandlerError, Context};
+use std::future::Future;
+use std::sync::Arc;
+use tokio::runtime::Runtime as TokioRuntime;
+
+type LambdaResponse = lambda_http::Response<lambda_http::Body>;
+
+trait ResultExt<OK, ERR> {
+    fn handler_error(self, description: &str) -> Result<OK, HandlerError>;
+}
+
+impl<OK, ERR> ResultExt<OK, ERR> for Result<OK, ERR> {
+    fn handler_error(self, description: &str) -> Result<OK, HandlerError> {
+        self.map_err(|_| HandlerError::from(description))
+    }
+}
+
+trait CompatHttpBodayAsLambda {
+    fn into_lambda(self) -> LambdaBody;
+}
+
+impl CompatHttpBodayAsLambda for Vec<u8> {
+    fn into_lambda(self) -> LambdaBody {
+        if self.is_empty() {
+            return LambdaBody::Empty;
+        }
+        match String::from_utf8(self) {
+            Ok(s) => LambdaBody::from(s),
+            Err(e) => LambdaBody::from(e.into_bytes()),
+        }
+    }
+}
+
+struct Server<S> {
+    service: Arc<S>,
+    rt: TokioRuntime,
+}
+
+impl<S> Server<S>
+where
+    S: HttpService,
+{
+    fn new(s: S) -> Server<S> {
+        Server {
+            service: Arc::new(s),
+            rt: tokio::runtime::Runtime::new().expect("failed to start new Runtime"),
+        }
+    }
+
+    fn serve(
+        &self,
+        req: LambdaHttpRequest,
+    ) -> impl Future<Output = Result<LambdaResponse, HandlerError>> {
+        let service = self.service.clone();
+        async move {
+            let req: HttpRequest = req.map(|b| HttpBody::from(b.as_ref()));
+            let mut connection = service
+                .connect()
+                .into_future()
+                .await
+                .handler_error("connect")?;
+            let (parts, body) = service
+                .respond(&mut connection, req)
+                .into_future()
+                .await
+                .handler_error("respond")?
+                .into_parts();
+            let resp = LambdaResponse::from_parts(
+                parts,
+                body.into_vec().await.handler_error("body")?.into_lambda(),
+            );
+            Ok(resp)
+        }
+    }
+}
+
+impl<S> Handler<LambdaResponse> for Server<S>
+where
+    S: HttpService,
+{
+    fn run(
+        &mut self,
+        req: LambdaHttpRequest,
+        _ctx: Context,
+    ) -> Result<LambdaResponse, HandlerError> {
+        // Lambda processes one event at a time in a Function. Each invocation
+        // is not in async context so it's ok to block here.
+        self.rt.block_on(self.serve(req).boxed().compat())
+    }
+}
+
+/// Run the given `HttpService` on the default runtime, using `lambda_http` as
+/// backend.
+pub fn run<S: HttpService>(s: S) {
+    let server = Server::new(s);
+    // Let Lambda runtime start its own tokio runtime
+    lambda_http::start(server, None);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::future;
+
+    struct DummyService;
+
+    impl HttpService for DummyService {
+        type Connection = ();
+        type ConnectionFuture = future::Ready<Result<(), ()>>;
+        type Fut = future::BoxFuture<'static, Result<http_service::Response, ()>>;
+        fn connect(&self) -> Self::ConnectionFuture {
+            future::ok(())
+        }
+        fn respond(&self, _conn: &mut (), _req: http_service::Request) -> Self::Fut {
+            Box::pin(async move { Ok(http_service::Response::new(http_service::Body::empty())) })
+        }
+    }
+
+    #[test]
+    fn handle_apigw_request() {
+        // from the docs
+        // https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-api-gateway-request
+        let input = include_str!("../tests/data/apigw_proxy_request.json");
+        let request = lambda_http::request::from_str(input).unwrap();
+        let mut handler = Server::new(DummyService);
+        let result = handler.run(request, Context::default());
+        assert!(
+            result.is_ok(),
+            format!("event was not handled as expected {:?}", result)
+        );
+    }
+
+    #[test]
+    fn handle_alb_request() {
+        // from the docs
+        // https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#multi-value-headers
+        let input = include_str!("../tests/data/alb_request.json");
+        let request = lambda_http::request::from_str(input).unwrap();
+        let mut handler = Server::new(DummyService);
+        let result = handler.run(request, Context::default());
+        assert!(
+            result.is_ok(),
+            format!("event was not handled as expected {:?}", result)
+        );
+    }
+}

--- a/http-service-lambda/src/lib.rs
+++ b/http-service-lambda/src/lib.rs
@@ -48,11 +48,11 @@ impl<OK, ERR> ResultExt<OK, ERR> for Result<OK, ERR> {
     }
 }
 
-trait CompatHttpBodayAsLambda {
+trait CompatHttpBodyAsLambda {
     fn into_lambda(self) -> LambdaBody;
 }
 
-impl CompatHttpBodayAsLambda for Vec<u8> {
+impl CompatHttpBodyAsLambda for Vec<u8> {
     fn into_lambda(self) -> LambdaBody {
         if self.is_empty() {
             return LambdaBody::Empty;

--- a/http-service-lambda/src/lib.rs
+++ b/http-service-lambda/src/lib.rs
@@ -140,11 +140,11 @@ mod tests {
     impl HttpService for DummyService {
         type Connection = ();
         type ConnectionFuture = future::Ready<Result<(), ()>>;
-        type Fut = future::BoxFuture<'static, Result<http_service::Response, ()>>;
+        type ResponseFuture = future::BoxFuture<'static, Result<http_service::Response, ()>>;
         fn connect(&self) -> Self::ConnectionFuture {
             future::ok(())
         }
-        fn respond(&self, _conn: &mut (), _req: http_service::Request) -> Self::Fut {
+        fn respond(&self, _conn: &mut (), _req: http_service::Request) -> Self::ResponseFuture {
             Box::pin(async move { Ok(http_service::Response::new(http_service::Body::empty())) })
         }
     }

--- a/http-service-lambda/tests/data/alb_request.json
+++ b/http-service-lambda/tests/data/alb_request.json
@@ -1,0 +1,24 @@
+{
+  "requestContext": {
+      "elb": {
+          "targetGroupArn": "arn:aws:elasticloadbalancing:region:123456789012:targetgroup/my-target-group/6d0ecf831eec9f09"
+      }
+  },
+  "httpMethod": "GET",
+  "path": "/",
+  "queryStringParameters": { "myKey": "val2"},
+  "headers": {
+      "accept": "text/html,application/xhtml+xml",
+      "accept-language": "en-US,en;q=0.8",
+      "content-type": "text/plain",
+      "cookie": "cookies",
+      "host": "lambda-846800462-us-east-2.elb.amazonaws.com",
+      "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6)",
+      "x-amzn-trace-id": "Root=1-5bdb40ca-556d8b0c50dc66f0511bf520",
+      "x-forwarded-for": "72.21.198.66",
+      "x-forwarded-port": "443",
+      "x-forwarded-proto": "https"
+  },
+  "isBase64Encoded": false,
+  "body": "request_body"
+}

--- a/http-service-lambda/tests/data/apigw_proxy_request.json
+++ b/http-service-lambda/tests/data/apigw_proxy_request.json
@@ -1,0 +1,55 @@
+{
+  "path": "/test/hello",
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, lzma, sdch, br",
+    "Accept-Language": "en-US,en;q=0.8",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "wt6mne2s9k.execute-api.us-west-2.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48",
+    "Via": "1.1 fb7cca60f0ecd82ce07790c9c5eef16c.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "nBsWBOrSHMgnaROZJK1wGCZ9PcRcSpq_oSXZNQwQ10OTZL4cimZo3g==",
+    "X-Forwarded-For": "192.168.100.1, 192.168.1.1",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "pathParameters": {
+    "proxy": "hello"
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "us4z18",
+    "stage": "test",
+    "requestId": "41b45ea3-70b5-11e6-b7bd-69b5aaebc7d9",
+    "identity": {
+      "cognitoIdentityPoolId": "",
+      "accountId": "",
+      "cognitoIdentityId": "",
+      "caller": "",
+      "apiKey": "",
+      "sourceIp": "192.168.100.1",
+      "cognitoAuthenticationType": "",
+      "cognitoAuthenticationProvider": "",
+      "userArn": "",
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48",
+      "user": ""
+    },
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "apiId": "wt6mne2s9k"
+  },
+  "resource": "/{proxy+}",
+  "httpMethod": "GET",
+  "queryStringParameters": {
+    "name": "me"
+  },
+  "stageVariables": {
+    "stageVarName": "stageVarValue"
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add a new server backend that runs on the `aws-lambda-rust-runtime`. Example usage:

```rust
fn main() {
    let mut app = tide::App::new(());
    app.at("/").get(async move |_| "Hello, world!");
    http_service_lambda::run(app.into_http_service());
}
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Because I wanted to use a framework like `tide` to handle requests in a Lambda function.
Related issue: https://github.com/rustasync/http-service/issues/10

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Build the example code and deployed to a Lambda function. I also ported one app that uses tide to Lambda.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
