### PR TITLE
Upgrade Rust version, repair CI status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - nightly-2019-05-09
+  - nightly-2019-07-08
 cache: cargo
 
 matrix:

--- a/http-service-lambda/Cargo.toml
+++ b/http-service-lambda/Cargo.toml
@@ -25,4 +25,4 @@ version = "0.3.0-alpha.16"
 [dev-dependencies]
 log = "0.4.6"
 simple_logger = { version = "1.3.0", default-features = false }
-tide = "0.2.0"
+tide = { version = "0.2.0", features = [], default-features = false }

--- a/http-service-lambda/examples/hello_world.rs
+++ b/http-service-lambda/examples/hello_world.rs
@@ -1,4 +1,4 @@
-#![feature(async_await)]
+#![feature(async_await, async_closure)]
 use simple_logger;
 use tide::middleware::DefaultHeaders;
 


### PR DESCRIPTION
The dependency that seems to be preventing a successful CI run is `tide-cors` (see #38). We don't have a need to build that middleware while testing `http-service-lambda`, so I removed it (along with other extra features).

Hopefully this corrects my mistake of breaking CI on `master`.
cc: @rustasync/maintainers 