### PR TITLE
Refactor example that required the async_closure feature flag

### DIFF
--- a/http-service-lambda/examples/hello_world.rs
+++ b/http-service-lambda/examples/hello_world.rs
@@ -13,7 +13,7 @@ fn main() {
             .header("X-Server", "Tide"),
     );
 
-    app.at("/").get(async move |_| "Hello, world!");
+    app.at("/").get(|_| async move { "Hello, world!" });
 
     http_service_lambda::run(app.into_http_service());
 }


### PR DESCRIPTION
Following the lead of [rustasync/tide#289](https://github.com/rustasync/tide/pull/289), this PR removes usage of the [`async_closure` feature gate](https://github.com/rust-lang/rust/issues/62290) because [it is currently deferred](https://github.com/rust-lang-nursery/futures-rs/pull/1716#issuecomment-508964777).