### PR TITLE
Read trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,7 @@ members = ["http-service-hyper", "http-service-lambda", "http-service-mock"]
 bytes = "0.4.12"
 futures = "0.3.1"
 http = "0.1.17"
-
-[dev-dependencies]
-http-service-hyper = { version = "0.3.1", path = "./http-service-hyper" }
+async-std = "0.99.11"
 
 [patch.crates-io]
 http-service = { path = "." }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = ["http-service-hyper", "http-service-lambda", "http-service-mock"]
 bytes = "0.4.12"
 futures = "0.3.1"
 http = "0.1.17"
-async-std = "0.99.11"
+async-std = "=0.99.11"
 
 [patch.crates-io]
 http-service = { path = "." }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ members = ["http-service-hyper", "http-service-lambda", "http-service-mock"]
 bytes = "0.4.12"
 futures = "0.3.1"
 http = "0.1.17"
-async-std = "=0.99.11"
+async-std = { version = "1.0.1", default-features = false, features = ["std"] }
+pin-project-lite = "0.1.0"
 
 [patch.crates-io]
 http-service = { path = "." }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ http = "0.1.17"
 async-std = { version = "1.0.1", default-features = false, features = ["std"] }
 pin-project-lite = "0.1.0"
 
+[dev-dependencies]
+http-service-hyper = { version = "0.3.1", path = "./http-service-hyper" }
+
 [patch.crates-io]
 http-service = { path = "." }
 http-service-hyper = { path = "./http-service-hyper" }

--- a/README.md
+++ b/README.md
@@ -37,91 +37,37 @@
   </h3>
 </div>
 
-<div align="center">
-  <sub>Built with ⛵ by <a href="https://github.com/rustasync">The Rust Async Ecosystem WG</a>
-</div>
-
 ## About
 
-The crate `http-service` provides the necessary types and traits to implement your own HTTP Server. It uses `hyper` for the lower level TCP abstraction.
+The crate `http-service` provides the necessary types and traits to implement
+your own HTTP Server.
 
-You can use the workspace member [`http-service-hyper`](https://crates.io/crates/http-service-hyper) to run your HTTP Server.
+For example you can use the workspace member
+[`http-service-hyper`](https://crates.io/crates/http-service-hyper) to run an
+HTTP Server.
 
 1. Runs via `http_service_hyper::run(HTTP_SERVICE, ADDRESS);`
-2. Returns a future which can be `await`ed via `http_service_hyper::serve(HTTP_SERVICE, ADDRESS);`
-
-This crate uses the latest [Futures](https://github.com/rust-lang-nursery/futures-rs) preview, and therefore needs to be run on Rust Nightly.
-
-## Examples
-
-**Cargo.toml**
-
-```toml
-[dependencies]
-http-service = "0.3.1"
-http-service-hyper = "0.3.1"
-futures-preview = "0.3.0-alpha.16"
-```
-
-**main.rs**
-
-```rust,no_run
-use futures::future::{self, BoxFuture, FutureExt};
-use http_service::{HttpService, Response};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
-struct Server {
-    message: Vec<u8>,
-}
-
-impl Server {
-    fn create(message: Vec<u8>) -> Server {
-        Server { message }
-    }
-
-    pub fn run(s: Server) {
-        let a = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8088);
-        http_service_hyper::run(s, a);
-    }
-}
-
-impl HttpService for Server {
-    type Connection = ();
-    type ConnectionFuture = future::Ready<Result<(), std::io::Error>>;
-    type ResponseFuture = BoxFuture<'static, Result<http_service::Response, std::io::Error>>;
-
-    fn connect(&self) -> Self::ConnectionFuture {
-        future::ok(())
-    }
-
-    fn respond(&self, _conn: &mut (), _req: http_service::Request) -> Self::ResponseFuture {
-        let message = self.message.clone();
-        async move { Ok(Response::new(http_service::Body::from(message))) }.boxed()
-    }
-}
-
-fn main() {
-    let s = Server::create(String::from("Hello, World").into_bytes());
-    Server::run(s);
-}
-```
+2. Returns a future which can be `await`ed via
+   `http_service_hyper::serve(HTTP_SERVICE, ADDRESS);`
 
 ## Contributing
 
-Want to join us? Check out our [The "Contributing" section of the guide][contributing] and take a look at some of these issues:
+Want to join us? Check out our [The "Contributing" section of the
+guide][contributing] and take a look at some of these issues:
 
 - [Issues labeled "good first issue"][good-first-issue]
 - [Issues labeled "help wanted"][help-wanted]
 
 #### Conduct
 
-The http-service project adheres to the [Contributor Covenant Code of Conduct](https://github.com/rustasync/.github/blob/master/CODE_OF_CONDUCT.md).
+The http-service project adheres to the [Contributor Covenant Code of
+Conduct](https://github.com/http-rs/.github/blob/master/CODE_OF_CONDUCT.md).
 This describes the minimum behavior expected from all contributors.
 
 ## License
 
 [MIT](./LICENSE-MIT) OR [Apache-2.0](./LICENSE-APACHE)
 
-[contributing]: https://github.com/rustasync/.github/blob/master/CONTRIBUTING.md
-[good-first-issue]: https://github.com/rustasync/http-service/labels/good%20first%20issue
-[help-wanted]: https://github.com/rustasync/http-service/labels/help%20wanted
+[contributing]: https://github.com/http-rs/.github/blob/master/CONTRIBUTING.md
+[good-first-issue]: https://github.com/http-rs/http-service/labels/good%20first%20issue
+[help-wanted]: https://github.com/http-rs/http-service/labels/help%20wanted

--- a/http-service-hyper/src/lib.rs
+++ b/http-service-hyper/src/lib.rs
@@ -76,7 +76,7 @@ where
                 .map(|chunk| chunk.map(|chunk| chunk.to_vec()))
                 .map_err(|e| io::Error::new(io::ErrorKind::Other, e));
             let body_reader = body_stream.into_async_read();
-            Body::from_reader(Box::new(body_reader))
+            Body::from_reader(body_reader)
         });
 
         let fut = self.service.respond(&mut self.connection, req);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,126 +1,67 @@
 //! Types and traits giving an interface between low-level http server implementations
 //! and services that use them. The interface is based on the `std::futures` API.
-//!
-//! ## Example
-//! ```rust,no_run
-//! use futures::{
-//!     future::{self, BoxFuture, FutureExt},
-//! };
-//! use http_service::{HttpService, Response};
-//! use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-//!
-//! struct Server {
-//!     message: Vec<u8>,
-//! }
-//!
-//! impl Server {
-//!     fn create(message: Vec<u8>) -> Server {
-//!         Server {
-//!             message,
-//!         }
-//!     }
-//!
-//!     pub fn run(s: Server) {
-//!         let a = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
-//!         http_service_hyper::run(s, a);
-//!     }
-//! }
-//!
-//! impl HttpService for Server {
-//!     type Connection = ();
-//!     type ConnectionFuture = future::Ready<Result<(), std::io::Error>>;
-//!     type ResponseFuture = BoxFuture<'static, Result<http_service::Response, std::io::Error>>;
-//!
-//!     fn connect(&self) -> Self::ConnectionFuture {
-//!         future::ok(())
-//!     }
-//!
-//!     fn respond(&self, _conn: &mut (), _req: http_service::Request) -> Self::ResponseFuture {
-//!         let message = self.message.clone();
-//!         async move { Ok(Response::new(http_service::Body::from(message))) }.boxed()
-//!     }
-//! }
-//!
-//! fn main() {
-//!     let s = Server::create(String::from("Hello, World").into_bytes());
-//!     Server::run(s);
-//! }
-//! ```
 
-#![forbid(future_incompatible, rust_2018_idioms)]
-#![deny(missing_debug_implementations, nonstandard_style)]
-#![warn(missing_docs, missing_doc_code_examples)]
-#![cfg_attr(any(feature = "nightly", test), feature(external_doc))]
-#![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
-#![cfg_attr(test, deny(warnings))]
+#![warn(missing_debug_implementations, rust_2018_idioms)]
+#![allow(clippy::mutex_atomic, clippy::module_inception)]
+#![doc(test(attr(deny(rust_2018_idioms, warnings))))]
+#![doc(test(attr(allow(unused_extern_crates, unused_variables))))]
 
-use bytes::Bytes;
-use futures::{
-    future,
-    prelude::*,
-    stream::{self, BoxStream},
-    task::{Context, Poll},
-};
+use async_std::io::{self, prelude::*};
+use async_std::prelude::*;
+use async_std::task::{Context, Poll};
 
 use std::fmt;
 use std::pin::Pin;
 
-#[cfg(test)]
-#[doc(include = "../README.md")]
-const _README: () = ();
-
 /// The raw body of an http request or response.
-///
-/// A body is a stream of `Bytes` values, which are shared handles to byte buffers.
-/// Both `Body` and `Bytes` values can be easily created from standard owned byte buffer types
-/// like `Vec<u8>` or `String`, using the `From` trait.
 pub struct Body {
-    stream: BoxStream<'static, Result<Bytes, std::io::Error>>,
+    reader: Box<dyn Read + Unpin + Send + 'static>,
 }
 
 impl Body {
-    /// Create an empty body.
+    /// Create a new empty body.
     pub fn empty() -> Self {
-        Body::from_stream(stream::empty())
-    }
-
-    /// Create a body from a stream of `Bytes`
-    pub fn from_stream<S>(s: S) -> Self
-    where
-        S: Stream<Item = Result<Bytes, std::io::Error>> + Send + 'static,
-    {
-        Self { stream: s.boxed() }
-    }
-
-    /// Reads the stream into a new `Vec`.
-    #[allow(clippy::wrong_self_convention)] // https://github.com/rust-lang/rust-clippy/issues/4037
-    pub async fn into_vec(mut self) -> std::io::Result<Vec<u8>> {
-        let mut bytes = Vec::new();
-        while let Some(chunk) = self.next().await {
-            bytes.extend(chunk?);
+        Self {
+            reader: Box::new(io::empty()),
         }
-        Ok(bytes)
+    }
+
+    /// Create a new instance from a reader.
+    pub fn from_reader(reader: impl Read + Unpin + Send + 'static) -> Self {
+        Self {
+            reader: Box::new(reader),
+        }
     }
 }
 
-impl<T: Into<Bytes> + Send> From<T> for Body {
-    fn from(x: T) -> Self {
-        Self::from_stream(stream::once(future::ok(x.into())))
-    }
-}
-
-impl Unpin for Body {}
-
-impl Stream for Body {
-    type Item = Result<Bytes, std::io::Error>;
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.stream.poll_next_unpin(cx)
+impl Read for Body {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.reader).poll_read(cx, buf)
     }
 }
 
 impl fmt::Debug for Body {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Body").finish()
+        f.debug_struct("Body").field("reader", &"<hidden>").finish()
+    }
+}
+
+impl From<Vec<u8>> for Body {
+    fn from(vec: Vec<u8>) -> Body {
+        Self {
+            reader: Box::new(io::Cursor::new(vec)),
+        }
+    }
+}
+
+impl<R: Read + Unpin + Send + 'static> From<Box<R>> for Body {
+    /// Converts an `AsyncRead` into a Body.
+    fn from(reader: Box<R>) -> Self {
+        Self { reader }
     }
 }
 
@@ -134,56 +75,28 @@ pub type Response = http::Response<Body>;
 ///
 /// An instance represents a service as a whole. The associated `Conn` type
 /// represents a particular connection, and may carry connection-specific state.
-pub trait HttpService: Send + Sync + 'static {
-    /// An individual connection.
-    ///
-    /// This associated type is used to establish and hold any per-connection state
-    /// needed by the service.
-    type Connection: Send + 'static;
-
-    /// A future for setting up an individual connection.
-    ///
-    /// This method is called each time the server receives a new connection request,
-    /// but before actually exchanging any data with the client.
-    ///
-    /// Returning an error will result in the server immediately dropping
-    /// the connection.
-    type ConnectionFuture: Send + 'static + TryFuture<Ok = Self::Connection>;
-
-    /// Initiate a new connection.
-    ///
-    /// This method is given access to the global service (`&self`), which may provide
-    /// handles to connection pools, thread pools, or other global data.
-    fn connect(&self) -> Self::ConnectionFuture;
-
+pub trait HttpService<E>: Send + Sync + 'static {
     /// The async computation for producing the response.
     ///
     /// Returning an error will result in the server immediately dropping
     /// the connection. It is usually preferable to instead return an HTTP response
     /// with an error status code.
-    type ResponseFuture: Send + 'static + TryFuture<Ok = Response>;
+    type ResponseFuture: Send + 'static + Future<Output = Result<Response, E>>;
 
     /// Begin handling a single request.
     ///
     /// The handler is given shared access to the service itself, and mutable access
     /// to the state for the connection where the request is taking place.
-    fn respond(&self, conn: &mut Self::Connection, req: Request) -> Self::ResponseFuture;
+    fn respond(&self, req: Request) -> Self::ResponseFuture;
 }
 
-impl<F, R> HttpService for F
+impl<F, R, E> HttpService<E> for F
 where
     F: Send + Sync + 'static + Fn(Request) -> R,
-    R: Send + 'static + TryFuture<Ok = Response>,
-    R::Error: Send,
+    R: Send + 'static + Future<Output = Result<Response, E>>,
 {
-    type Connection = ();
-    type ConnectionFuture = future::Ready<Result<(), R::Error>>;
-    fn connect(&self) -> Self::ConnectionFuture {
-        future::ok(())
-    }
-
     type ResponseFuture = R;
-    fn respond(&self, _: &mut (), req: Request) -> Self::ResponseFuture {
+    fn respond(&self, req: Request) -> Self::ResponseFuture {
         (self)(req)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pin_project_lite::pin_project! {
     /// The raw body of an http request or response.
     pub struct Body {
         #[pin]
-        reader: Box<dyn BufRead + Unpin + Send + 'static>,
+        reader: Pin<Box<dyn BufRead + Send + 'static>>,
     }
 }
 
@@ -26,14 +26,14 @@ impl Body {
     /// Create a new empty body.
     pub fn empty() -> Self {
         Self {
-            reader: Box::new(io::empty()),
+            reader: Box::pin(io::empty()),
         }
     }
 
     /// Create a new instance from a reader.
     pub fn from_reader(reader: impl BufRead + Unpin + Send + 'static) -> Self {
         Self {
-            reader: Box::new(reader),
+            reader: Box::pin(reader),
         }
     }
 }
@@ -68,14 +68,14 @@ impl fmt::Debug for Body {
 impl From<Vec<u8>> for Body {
     fn from(vec: Vec<u8>) -> Body {
         Self {
-            reader: Box::new(io::Cursor::new(vec)),
+            reader: Box::pin(io::Cursor::new(vec)),
         }
     }
 }
 
-impl<R: BufRead + Unpin + Send + 'static> From<Box<R>> for Body {
+impl<R: BufRead + Unpin + Send + 'static> From<Pin<Box<R>>> for Body {
     /// Converts an `AsyncRead` into a Body.
-    fn from(reader: Box<R>) -> Self {
+    fn from(reader: Pin<Box<R>>) -> Self {
         Self { reader }
     }
 }


### PR DESCRIPTION
WIP, replaces `Stream<Output = Bytes>` with `AsyncRead`. Though I'd like to turn this into an `AsyncBufRead` instead to improve on allocations. Closes #31.

Either way, I'll be using this as a starting point for the work in https://github.com/http-rs/tide/issues/336#issuecomment-549099461. Thanks!