### PR TITLE
Upgrade http-service to use futures 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,13 +20,11 @@ members = ["http-service-hyper", "http-service-lambda", "http-service-mock"]
 
 [dependencies]
 bytes = "0.4.12"
+futures = "0.3.1"
 http = "0.1.17"
 
 [dev-dependencies]
 http-service-hyper = { version = "0.3.1", path = "./http-service-hyper" }
-
-[dependencies.futures-preview]
-version = "0.3.0-alpha.16"
 
 [patch.crates-io]
 http-service = { path = "." }

--- a/http-service-hyper/Cargo.toml
+++ b/http-service-hyper/Cargo.toml
@@ -17,9 +17,9 @@ http = "0.1"
 http-service = { version = "0.3.1", path = ".." }
 hyper = { version = "0.12.27", default-features = false }
 
-[dependencies.futures-preview]
+[dependencies.futures]
 features = ["compat", "io-compat"]
-version = "0.3.0-alpha.16"
+version = "0.3.1"
 
 [features]
 default = ["runtime"]

--- a/http-service-lambda/Cargo.toml
+++ b/http-service-lambda/Cargo.toml
@@ -18,11 +18,11 @@ lambda_http = "0.1.1"
 lambda_runtime = "0.2.1"
 tokio = "0.1.21"
 
-[dependencies.futures-preview]
+[dependencies.futures]
 features = ["compat"]
-version = "0.3.0-alpha.16"
+version = "0.3.1"
 
 [dev-dependencies]
 log = "0.4.6"
 simple_logger = { version = "1.3.0", default-features = false }
-tide = { version = "0.2.0", features = [], default-features = false }
+tide = { version = "0.3.0", features = [], default-features = false }

--- a/http-service-mock/Cargo.toml
+++ b/http-service-mock/Cargo.toml
@@ -12,7 +12,5 @@ documentation = "https://docs.rs/http-service-mock"
 version = "0.3.1"
 
 [dependencies]
+futures = "0.3.1"
 http-service = { version = "0.3.1", path = ".." }
-
-[dependencies.futures-preview]
-version = "0.3.0-alpha.16"


### PR DESCRIPTION
**Edit:** All check builds passed after I upgraded all `futures-preview` to `futures`. Maybe I missed something when it failed.

---

Note that only `http-service` compiles at this time. The purpose of this PR is to unblock `tide` from build errors; upgrading only the core crate would be sufficient for now.

I don't mean `http-service` adapter crates should be abandoned. Especially, I'm interested in making `http-service-hyper` work with latest Hyper. However it looks like a *huge* task, and Hyper isn't using futures 0.3 yet, so it's a future work to upgrade `http-service-hyper`.