### PR TITLE
Update http-service-lambda to work with http-service version 0.4

### DIFF
--- a/http-service-lambda/Cargo.toml
+++ b/http-service-lambda/Cargo.toml
@@ -10,19 +10,16 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "http-service-lambda"
 repository = "https://github.com/rustasync/http-service"
-version = "0.3.1"
+version = "0.4.0"
 
 [dependencies]
 http-service = { version = "0.4.0", path = ".." }
 lambda_http = "0.1.1"
 lambda_runtime = "0.2.1"
-tokio = "0.1.21"
-
-[dependencies.futures]
-features = ["compat"]
-version = "0.3.1"
+futures = { version = "0.3.1", features = ["compat"] }
+tokio = "0.1.22"
 
 [dev-dependencies]
 log = "0.4.6"
 simple_logger = { version = "1.3.0", default-features = false }
-tide = { version = "0.3.0", features = [], default-features = false }
+tide = { version = "0.4.0", features = [], default-features = false }

--- a/http-service-lambda/examples/README.md
+++ b/http-service-lambda/examples/README.md
@@ -10,7 +10,7 @@ Alternatively, build the example and deploy to lambda manually:
 
     ```sh
     rustup target add x86_64-unknown-linux-musl
-    cargo +nightly build --release --example hello_world --target x86_64-unknown-linux-musl
+    cargo build --release --example hello_world --target x86_64-unknown-linux-musl
     ```
 
 2. Package

--- a/http-service-lambda/examples/hello_world.rs
+++ b/http-service-lambda/examples/hello_world.rs
@@ -1,17 +1,10 @@
+use http_service_lambda;
 use simple_logger;
-use tide::middleware::DefaultHeaders;
 
 fn main() {
     simple_logger::init_with_level(log::Level::Info).unwrap();
 
-    let mut app = tide::App::new();
-
-    app.middleware(
-        DefaultHeaders::new()
-            .header("X-Version", "1.0.0")
-            .header("X-Server", "Tide"),
-    );
-
+    let mut app = tide::new();
     app.at("/").get(|_| async move { "Hello, world!" });
 
     http_service_lambda::run(app.into_http_service());

--- a/http-service-lambda/src/lib.rs
+++ b/http-service-lambda/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! ```rust,ignore
 //! fn main() {
-//!     let mut app = tide::App::new();
+//!     let mut app = tide::new();
 //!     app.at("/").get(async move |_| "Hello, world!");
 //!     http_service_lambda::run(app.into_http_service());
 //! }
@@ -25,112 +25,139 @@
 #![warn(missing_docs, missing_doc_code_examples)]
 #![cfg_attr(test, deny(warnings))]
 
-use futures::{FutureExt, TryFutureExt};
+use futures::{
+    channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
+    AsyncReadExt, Future, FutureExt, StreamExt, TryFutureExt,
+};
 use http_service::{Body as HttpBody, HttpService, Request as HttpRequest};
-use lambda_http::{Body as LambdaBody, Handler, Request as LambdaHttpRequest};
+use lambda_http::{lambda, Body as LambdaBody, Handler, Request as LambdaHttpRequest};
 use lambda_runtime::{error::HandlerError, Context};
-use std::future::Future;
-use std::sync::Arc;
+use std::{
+    sync::mpsc::{channel as sync_channel, Sender as SyncSender},
+    thread,
+};
 use tokio::runtime::Runtime as TokioRuntime;
 
-type LambdaResponse = lambda_http::Response<lambda_http::Body>;
+type LambdaResponse = lambda_http::Response<LambdaBody>;
 
-trait ResultExt<OK, ERR> {
-    fn handler_error(self, description: &str) -> Result<OK, HandlerError>;
+trait ResultExt<Ok, Error> {
+    fn handler_error(self, description: &str) -> Result<Ok, HandlerError>;
 }
 
-impl<OK, ERR> ResultExt<OK, ERR> for Result<OK, ERR> {
-    fn handler_error(self, description: &str) -> Result<OK, HandlerError> {
+impl<Ok, Error> ResultExt<Ok, Error> for Result<Ok, Error> {
+    fn handler_error(self, description: &str) -> Result<Ok, HandlerError> {
         self.map_err(|_| HandlerError::from(description))
     }
 }
 
-trait CompatHttpBodyAsLambda {
-    fn into_lambda(self) -> LambdaBody;
-}
-
-impl CompatHttpBodyAsLambda for Vec<u8> {
-    fn into_lambda(self) -> LambdaBody {
-        if self.is_empty() {
-            return LambdaBody::Empty;
-        }
-        match String::from_utf8(self) {
-            Ok(s) => LambdaBody::from(s),
-            Err(e) => LambdaBody::from(e.into_bytes()),
-        }
-    }
-}
+type RequestSender = UnboundedSender<(LambdaHttpRequest, ResponseSender)>;
+type RequestReceiver = UnboundedReceiver<(LambdaHttpRequest, ResponseSender)>;
+type ResponseSender = SyncSender<Result<LambdaResponse, HandlerError>>;
 
 struct Server<S> {
-    service: Arc<S>,
-    rt: TokioRuntime,
+    service: S,
+    requests: RequestReceiver,
 }
 
-impl<S> Server<S>
-where
-    S: HttpService,
-{
-    fn new(s: S) -> Server<S> {
-        Server {
-            service: Arc::new(s),
-            rt: tokio::runtime::Runtime::new().expect("failed to start new Runtime"),
-        }
+impl<S: HttpService> Server<S> {
+    fn new(service: S, requests: RequestReceiver) -> Server<S> {
+        Server { service, requests }
     }
 
-    fn serve(
-        &self,
-        req: LambdaHttpRequest,
-    ) -> impl Future<Output = Result<LambdaResponse, HandlerError>> {
-        let service = self.service.clone();
-        async move {
-            let req: HttpRequest = req.map(|b| HttpBody::from(b.as_ref()));
-            let mut connection = service
-                .connect()
-                .into_future()
-                .await
-                .handler_error("connect")?;
-            let (parts, body) = service
-                .respond(&mut connection, req)
-                .into_future()
-                .await
-                .handler_error("respond")?
-                .into_parts();
-            let resp = LambdaResponse::from_parts(
-                parts,
-                body.into_vec().await.handler_error("body")?.into_lambda(),
-            );
-            Ok(resp)
+    async fn run(mut self) -> Result<(), ()> {
+        while let Some((req, reply)) = self.requests.next().await {
+            let response = self.serve(req).await;
+            reply.send(response).unwrap();
         }
+        Ok(())
+    }
+
+    async fn serve(&self, req: LambdaHttpRequest) -> Result<LambdaResponse, HandlerError> {
+        // Create new connection
+        let mut connection = self
+            .service
+            .connect()
+            .into_future()
+            .await
+            .handler_error("connect")?;
+
+        // Convert Lambda request to HTTP request
+        let req: HttpRequest = req.map(|b| match b {
+            LambdaBody::Binary(v) => HttpBody::from(v),
+            LambdaBody::Text(s) => HttpBody::from(s.into_bytes()),
+            LambdaBody::Empty => HttpBody::empty(),
+        });
+
+        // Handle request
+        let (parts, mut body) = self
+            .service
+            .respond(&mut connection, req)
+            .into_future()
+            .await
+            .handler_error("respond")?
+            .into_parts();
+
+        // Convert response back to Lambda response
+        let mut buf = Vec::new();
+        body.read_to_end(&mut buf).await.handler_error("body")?;
+        let lambda_body = if buf.is_empty() {
+            LambdaBody::Empty
+        } else {
+            match String::from_utf8(buf) {
+                Ok(s) => LambdaBody::Text(s),
+                Err(b) => LambdaBody::Binary(b.into_bytes()),
+            }
+        };
+        Ok(LambdaResponse::from_parts(parts, lambda_body))
     }
 }
 
-impl<S> Handler<LambdaResponse> for Server<S>
-where
-    S: HttpService,
-{
+struct ProxyHandler(RequestSender);
+
+impl Handler<LambdaResponse> for ProxyHandler {
     fn run(
         &mut self,
-        req: LambdaHttpRequest,
+        event: LambdaHttpRequest,
         _ctx: Context,
     ) -> Result<LambdaResponse, HandlerError> {
-        // Lambda processes one event at a time in a Function. Each invocation
-        // is not in async context so it's ok to block here.
-        self.rt.block_on(self.serve(req).boxed().compat())
+        let (reply, response_chan) = sync_channel();
+        self.0
+            .unbounded_send((event, reply))
+            .handler_error("forward event")?;
+        response_chan.recv().handler_error("receive response")?
     }
 }
 
-/// Run the given `HttpService` on the default runtime, using `lambda_http` as
-/// backend.
+fn prepare_proxy<S: HttpService>(
+    service: S,
+) -> (ProxyHandler, impl Future<Output = Result<(), ()>>) {
+    let (request_sender, requests) = unbounded();
+    let server = Server::new(service, requests);
+    (ProxyHandler(request_sender), server.run())
+}
+
+/// Serve the given `HttpService` using `lambda_http` as backend and
+/// return a `Future` that can be `await`ed on.
+pub fn serve<S: HttpService>(s: S) -> impl Future<Output = Result<(), ()>> {
+    let (handler, server_task) = prepare_proxy(s);
+    thread::spawn(|| lambda!(handler));
+    server_task
+}
+
+/// Run the given `HttpService` on the default runtime, using
+/// `lambda_http` as backend.
 pub fn run<S: HttpService>(s: S) {
-    let server = Server::new(s);
-    // Let Lambda runtime start its own tokio runtime
-    lambda_http::start(server, None);
+    let (handler, server) = prepare_proxy(s);
+    let mut runtime = TokioRuntime::new().expect("Can not start tokio runtime");
+    runtime.spawn(server.boxed().compat());
+    lambda!(handler, runtime);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use futures::future;
+    use lambda_http::Handler;
 
     struct DummyService;
 
@@ -146,14 +173,19 @@ mod tests {
         }
     }
 
+    fn run_once(request: LambdaHttpRequest) -> Result<LambdaResponse, HandlerError> {
+        let (mut handler, server) = prepare_proxy(DummyService);
+        std::thread::spawn(|| futures::executor::block_on(server));
+        handler.run(request, Context::default())
+    }
+
     #[test]
     fn handle_apigw_request() {
         // from the docs
         // https://docs.aws.amazon.com/lambda/latest/dg/eventsources.html#eventsources-api-gateway-request
         let input = include_str!("../tests/data/apigw_proxy_request.json");
         let request = lambda_http::request::from_str(input).unwrap();
-        let mut handler = Server::new(DummyService);
-        let result = handler.run(request, Context::default());
+        let result = run_once(request);
         assert!(
             result.is_ok(),
             format!("event was not handled as expected {:?}", result)
@@ -166,8 +198,7 @@ mod tests {
         // https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#multi-value-headers
         let input = include_str!("../tests/data/alb_request.json");
         let request = lambda_http::request::from_str(input).unwrap();
-        let mut handler = Server::new(DummyService);
-        let result = handler.run(request, Context::default());
+        let result = run_once(request);
         assert!(
             result.is_ok(),
             format!("event was not handled as expected {:?}", result)


### PR DESCRIPTION
Added a new Runtime trait to allow customizing the async runtime so
that users can choose what they want to use and don't need to update
http-service-lambda in order to benefit from newer async runtime.