### PR TITLE
Set request peer and local addrs on Response and Request in http-service-h1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ version = "0.5.0"
 members = ["http-service-mock", "http-service-h1"]
 
 [dependencies]
-http-types = "1.0.1"
+http-types = "1.3.0"
 async-std = { version = "1.5.0", default-features = false, features = ["std"] }

--- a/http-service-h1/src/lib.rs
+++ b/http-service-h1/src/lib.rs
@@ -96,10 +96,12 @@ where
         req.local_addr = stream.0.local_addr().ok();
 
         async move {
-            let res = service
+            let mut res = service
                 .respond(conn, req)
                 .await
                 .map_err(|_| io::Error::from(io::ErrorKind::Other))?;
+            res.peer_addr = req.peer_addr.clone();
+            res.local_addr = req.local_addr.clone();
             Ok(res)
         }
         .await

--- a/http-service-h1/src/lib.rs
+++ b/http-service-h1/src/lib.rs
@@ -92,8 +92,8 @@ where
     async_h1::accept(&addr, stream.clone(), |req| async {
         let conn = conn.clone();
         let service = service.clone();
-        req.peer_addr = stream.0.peer_addr().ok();
-        req.local_addr = stream.0.local_addr().ok();
+        req.peer_addr = stream.0.peer_addr().map(|socket| socket.to_string()).ok();
+        req.local_addr = stream.0.local_addr().map(|socket| socket.to_string()).ok();
 
         async move {
             let mut res = service

--- a/http-service-h1/src/lib.rs
+++ b/http-service-h1/src/lib.rs
@@ -89,11 +89,11 @@ where
         .await
         .map_err(|_| io::Error::from(io::ErrorKind::Other))?;
 
-    async_h1::accept(&addr, stream.clone(), |req| async {
+    async_h1::accept(&addr, stream.clone(), |mut req| async {
         let conn = conn.clone();
         let service = service.clone();
-        req.peer_addr = stream.0.peer_addr().map(|socket| socket.to_string()).ok();
-        req.local_addr = stream.0.local_addr().map(|socket| socket.to_string()).ok();
+        req.set_peer_addr(stream.0.peer_addr().ok());
+        req.set_local_addr(stream.0.local_addr().ok());
 
         async move {
             let res = service

--- a/http-service-h1/src/lib.rs
+++ b/http-service-h1/src/lib.rs
@@ -96,12 +96,10 @@ where
         req.local_addr = stream.0.local_addr().map(|socket| socket.to_string()).ok();
 
         async move {
-            let mut res = service
+            let res = service
                 .respond(conn, req)
                 .await
                 .map_err(|_| io::Error::from(io::ErrorKind::Other))?;
-            res.peer_addr = req.peer_addr.clone();
-            res.local_addr = req.local_addr.clone();
             Ok(res)
         }
         .await

--- a/http-service-h1/src/lib.rs
+++ b/http-service-h1/src/lib.rs
@@ -92,6 +92,9 @@ where
     async_h1::accept(&addr, stream.clone(), |req| async {
         let conn = conn.clone();
         let service = service.clone();
+        req.peer_addr = stream.0.peer_addr().ok();
+        req.local_addr = stream.0.local_addr().ok();
+
         async move {
             let res = service
                 .respond(conn, req)


### PR DESCRIPTION
Set TcpStream peer and local addrs on Requests and Responses. Indirectly addresses https://github.com/http-rs/async-h1/issues/99

~Depends on https://github.com/http-rs/http-types/pull/119~

*edit:* Now that http-rs/http-types#119 is merged, this depends on https://github.com/http-rs/async-h1/pull/105 or something like that so that it can build against master of http-types to incorporate http-rs/http-types#119.